### PR TITLE
Fix tile.js unit tests

### DIFF
--- a/tests/unit/Tile.test.js
+++ b/tests/unit/Tile.test.js
@@ -2,7 +2,14 @@
 const { Tile } = require('../../Tile.js');
 console.log(Tile); // Making sure the Tile class is being imported.
 
-// Mock the `document` because these tests need a virtual DOM environment (because we aren't currently using a testing framework).
+// Accounting for global game state
+global.gameOver = false;
+
+global.hitMine = () => {
+  // Empty hitMine function mock to prevent Tile class from throwing error.
+};
+
+// Mock the `document` because these tests need a virtual DOM environment ==> we aren't currently using a testing framework so this is done manually.
 global.document = {
   createElement: (tagName) => {
     return {
@@ -11,6 +18,11 @@ global.document = {
         classes: [],
         add: function (className) {
           this.classes.push(className); // Simulates adding CSS classes to the element.
+        },
+        // Adding 'remove' to classList so toggle flag can be properly removed
+        // e.g. this.domElement.classList.remove('flagged')
+        remove: function (className) {
+          this.classes = this.classes.filter(c => c !== className);
         },
         contains: function (className) {
           return this.classes.includes(className); // Checks if a class is already present.
@@ -36,8 +48,13 @@ function runTest(testName, testFunction) {
 // These tests ensure the behavior of individual tiles is consistent/correct/predictable.
 
 function testTileInitialization() {
+
+  // ARRANGE
   const tile = new Tile();
 
+  // No "act" necessary 
+
+  // ASSERT
   // Verify the tile starts in a neutral state. This prevents unintended behavior
   // in the early game and ensures flags, mines, and reveals are applied correctly later.
   console.assert(tile.mine === false, "Tile should start without a mine to avoid accidental explosions.");
@@ -47,19 +64,29 @@ function testTileInitialization() {
 }
 
 function testSetMine() {
+
+  // ARRANGE
   const tile = new Tile();
+
+  // ACT
   tile.setMine();
 
+  // ASSERT
   // Here we make sure `setMine` marks a tile as containing a bomb is important for correct game logic,
   // especially when checking win/lose conditions.
   console.assert(tile.mine === true, "setMine() must mark the tile as containing a mine.");
 }
 
 function testRevealMine() {
+  
+  // ARRANGE
   const tile = new Tile();
+
+  // ACT
   tile.setMine();
   tile.reveal();
 
+  // ASSERT
   // Revealing a tile that contains a mine should display correctly
   // and mark the tile as revealed to avoid duplicate actions.
   console.assert(tile.revealed === true, "Revealing a tile should mark it as revealed.");
@@ -68,21 +95,32 @@ function testRevealMine() {
 }
 
 function testRevealEmpty() {
+
+  // ARRANGE
   const tile = new Tile();
+
+  // ACT
   tile.adjacentMines = 0;
   tile.reveal();
 
+  // ASSERT
   // When a tile has no adjacent mines, the game must make this clear
   // to prevent confusion and guide further play.
-  console.assert(tile.domElement.textContent === '0', "Tiles with no adjacent mines should display '0' for clarity.");
+  console.assert(tile.revealed === true, "Revealing a tile should mark it as revealed.");
+  console.assert(tile.domElement.textContent === '', "Empty tiles should display no text."); // Updated to match implementation (subject to change)
 }
 
 function testToggleFlag() {
+
+  // ARRANGE
   const tile = new Tile();
 
+  // ACT
   // Flags are a critical player tool for marking suspected mines.
   // Here we are making sure the flags mark correctly.
   tile.toggleFlag();
+
+  // ASSERT
   console.assert(tile.flagged === true, "toggleFlag() should flag the tile to help the player mark potential mines.");
   tile.toggleFlag();
   console.assert(tile.flagged === false, "toggleFlag() should unflag the tile to allow corrections.");
@@ -96,4 +134,10 @@ runTest("Reveal Mine", testRevealMine);
 runTest("Reveal Empty", testRevealEmpty);
 runTest("Toggle Flag", testToggleFlag);
 console.log("Tile Tests Completed.");
+
+
+//    RUNNING THIS TEST:
+// 1) Open terminal and navigate to the directory this file is located in
+// 2) enter `node ./Tile.test.js`
+
 


### PR DESCRIPTION
_In order to fix the Tile.js unit tests I did the following:_

[x] Accounted for new `gameOver` state
[x] Added global `hitMine()` mock
[x] Extended the DOM mocks classlist to add 'remove' functionality
[x] Updated `testRevealEmpty()` unit test assertions to align with new implementation